### PR TITLE
メッセージをユーザー詳細画面で送信して表示できるようにした。ユーザー一覧を表示できるようにした。

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,38 @@
  *= require_tree .
  *= require_self
  */
+
+
+body{
+  margin: 0px;
+}
+.container{
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  height: 100vh;
+}
+header{
+  background-color: rgba(245, 178, 177, 0.5);
+}
+main{
+  flex: 1;
+  background-color: rgba(255, 253, 237, 1);
+  overflow-y: scroll;
+}
+footer{
+  background-color: rgba(201, 187, 155, 0.5);
+}
+.msg{
+  display: inline-block;
+  border: solid 1px #454545;
+}
+.block-msg{
+  text-align: justify;
+}
+.user_show_header{
+  position: fixed;  
+}
+.header_user_name{
+  background-color: gray;
+}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,15 +1,19 @@
 class MessagesController < ApplicationController
+  before_action :authenticate_user!, except: [:new]
 
+  def index
+    @user = User.find(1)
+    @sent_messages = @user.sent_messages.order(created_at: :desc)
+  end
+  
   def new
-    
   end
   
   def create
-    @message = Message.new(message: params[:message])
-    # @message.user_id = current_user.id
+    @message = Message.new(message: params[:message], sender_id: current_user.id, recipient_id: params[:recipient_id])
       if @message.save
         flash[:notice] = "メッセージ作成に成功しました"
-        redirect_to "/"
+        redirect_to "/user/#{params[:id]}"
       else
         flash[:error] = @message.errors.full_messages
         render :new, status: :unprocessable_entity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,15 @@
+class UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+  
+  def show
+    @user = User.find(params[:id])
+    @re_uname = @user.name
+    @current_uname = User.find_by(name: current_user.name)
+    @sent_messages = current_user.sent_messages.where(recipient_id: params[:id])
+    @received_messages = @user.sent_messages.where(recipient_id: current_user.id)
+    @messages = (@sent_messages + @received_messages).sort_by(&:created_at)
+  end
+
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,2 +1,4 @@
 class Message < ApplicationRecord
+  belongs_to :sender, class_name: 'User', foreign_key: 'sender_id'
+  belongs_to :recipient, class_name: 'User', foreign_key: 'recipient_id'
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,9 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+        :recoverable, :rememberable, :validatable
+
+  has_many :sent_messages, class_name: 'Message', foreign_key: 'sender_id'
+  has_many :received_messages, class_name: 'Message', foreign_key: 'recipient_id'
+      
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,25 +11,28 @@
   </head>
 
   <body>
-    <% if user_signed_in? %>
+
       <header>
-        <div><%= current_user.name %></div>
-        <div><%= link_to "トップ", root_path, class: "text-white" %></div>
-        <div><%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "text-white" %></div>
-    <% else %>
-        <div><%= link_to "サインアップ", new_user_registration_path, class: "text-white" %></div>
-        <div><%= link_to "ログイン", new_user_session_path, class: "text-white" %></div>
-      </header>
-    <% end %> 
+        <% if user_signed_in? %>
+            <div><%= current_user.name %></div>
+            <div><%= link_to "トップ", root_path, class: "text-white" %></div>
+            <div><%= link_to "ユーザー一覧", users_path, class: "text-white" %></div>
+            <div><%= link_to "新規投稿", new_message_path, class: "text-white" %></div>
+            <div><%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "text-white" %></div>
+        <% else %>
+            <div><%= link_to "サインアップ", new_user_registration_path, class: "text-white" %></div>
+            <div><%= link_to "ログイン", new_user_session_path, class: "text-white" %></div>
+        <% end %> 
+          <div class="main">
+            <% flash.each do |key, value| %>
+                <p class="alert alert-<%= key %>">
+                  <%= value %>
+                </p>
+            <% end %>
+          </div>
+      </header> 
+        <%= yield %>
+        
 
-      <div class="main">
-        <% flash.each do |key, value| %>
-            <p class="alert alert-<%= key %>">
-              <%= value %>
-            </p>
-        <% end %>
-      </div>
-
-    <%= yield %>
   </body>
 </html>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,0 +1,11 @@
+<h1>Sent Messages</h1>
+
+<ul>
+  <% @sent_messages.each do |message| %>
+    <li>
+      Sent to: <%= message.recipient.email %>
+      Message: <%= message.message %>
+      Sent at: <%= message.created_at %>
+    </li>
+  <% end %>
+</ul>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,9 @@
+
+  <% @users.each do |user| %>
+    <div class="one-post card w-100">
+      <%= link_to user_path(user) do %>
+      <p class="caption h4"><%= user.name %></p>
+      <%= link_to "ユーザーへメッセージ", user_path(user), class: "text-white" %>
+      <% end %>
+    </div>
+  <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,55 @@
+
+  <div class="container">
+    <% if current_page?(user_path) %>
+      <header>
+        <div class="header_user_name">
+          <%= @user.name %>
+        </div>
+      </header>
+    <% end %>
+    <main class="main">
+      <h1>Users#show</h1>
+        
+      <%= link_to "トップページ", root_path %>
+      <br>
+      <div class="re_name">
+        <%= @user.name %>
+      <div>
+        <% @messages.each do |msg| %>
+          <% if msg.sender_id == current_user.id %>
+            <div style="text-align: right;">
+              <%= msg.sender_id %>
+              <%= msg.recipient_id %>
+              <%= current_user.name%>
+              <%= msg.message %>
+              <br>
+              <%= msg.created_at%>
+              <br>
+            </div>
+          <% elsif msg.sender_id == @user.id %>
+            <div style="text-align: left;">
+              <%= msg.sender_id %>
+              <%= msg.recipient_id %>
+              <%= msg.message %>
+              <br>
+              <%= msg.created_at%>
+              <br>
+            </div>
+          <% end %>
+        <% end %>
+    </main>
+
+    <footer>
+      <div>
+      <h2>新規投稿</h2>
+      <%= form_with url: messages_path do |f| %>
+
+        <p>message</p>
+        <%= f.text_area :message, size: "50x10" %></br>
+        <%= f.hidden_field :recipient_id, value: params[:id] %>
+
+        <%= f.submit '送信'%>
+      <% end %>
+      </div>
+    </footer>
+  </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Rails.application.routes.draw do
+
+  root to: "homes#index"
+
   devise_for :users
+  resources :users
 
   resources :messages
 
-  root :to =>  "homes#index"
+
 
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20231221145720_add_colunms_to_messages.rb
+++ b/db/migrate/20231221145720_add_colunms_to_messages.rb
@@ -1,0 +1,6 @@
+class AddColunmsToMessages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :messages, :sender_id, :integer
+    add_column :messages, :recipient_id, :integer
+  end
+end

--- a/db/migrate/20240102062205_add_foreign_key_to_messages.rb
+++ b/db/migrate/20240102062205_add_foreign_key_to_messages.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToMessages < ActiveRecord::Migration[7.0]
+  def change
+    add_foreign_key :messages, :users, column: :sender_id, column: :recipient_id, on_update: :cascade, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_17_094723) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_02_062205) do
   create_table "messages", force: :cascade do |t|
     t.string "message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "sender_id"
+    t.integer "recipient_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -30,4 +32,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_17_094723) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "messages", "users", column: "recipient_id", on_update: :cascade, on_delete: :cascade
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get users_index_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get users_show_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## 変更の概要
* メッセージをユーザー詳細画面で送信して表示できるようにした。
* ユーザー一覧を表示できるようにした。

## なぜこの変更をするのか
* ユーザー詳細画面でユーザーごとにメッセージを送信・表示した方が使いやすため。
* ユーザー一覧を表示することでメッセージ送信ユーザーを探しやすくするため。

## やったこと
* [x] やったこと
*[x] ユーザーの詳細画面でメッセージを全て表示し、ログイン者送信メッセージを右、詳細ページユーザー送信のメッセージを左に表示。
* [x] cssでヘッダーとフッタを固定し、詳細画面でメッセージのみスクロールして見れるようにした。
* [x] ユーザー一覧の表示
* [ ] やっていないこと
* cssでusers/show.html.erbでヘッダーフッターとメッセージ表示のバランスを整えてない。

## 変更内容
メッセージスクロール前
<img width="907" alt="image" src="https://github.com/gaburieru123/message_app2/assets/69755688/ce78bb65-042e-4ff1-b4b1-ee98051292a0">
メッセージスクロール後
<img width="922" alt="image" src="https://github.com/gaburieru123/message_app2/assets/69755688/e8950c34-3a5f-4b77-a386-7181b4c5d9c3">
ユーザー一覧
<img width="678" alt="image" src="https://github.com/gaburieru123/message_app2/assets/69755688/88ba233e-3ce7-4770-ac79-97024c0fbf3d">

## 影響範囲
* ユーザーに影響すること：メッセージを詳細画面で送信し、表示できる。ユーザー一覧からメッセージ送信相手を選べる。
* メンバーに影響すること：特になし
* システムに影響すること：特になし

## どうやるのか
* 使い方：ユーザー名をクリックして詳細画面に入り、メッセージフォームからメッセージ送信する。

## 課題
* 悩んでいること：特になし
* とくにレビューしてほしいところ：特になし

## 備考
* その他に伝えたいこと：特になし