### PR TITLE
メッセージ編集機能のアクセス制限追加。

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,8 +1,6 @@
 class MessagesController < ApplicationController
   before_action :authenticate_user!, except: [:new]
-
-  def index
-  end
+  before_action :correct_user, only: [:edit, :update]
   
   def new
   end
@@ -11,10 +9,41 @@ class MessagesController < ApplicationController
     message = Message.new(message: params[:message], sender_id: current_user.id, recipient_id: params[:recipient_id])
       if message.save
         flash[:notice] = "メッセージ作成に成功しました"
-        redirect_to "/user/#{params[:id]}"
+        redirect_to "/users/#{message.recipient_id}"
       else
         flash[:error] = message.errors.full_messages
         render :new, status: :unprocessable_entity
       end
   end
+
+  def edit
+    @message = Message.find(params[:id])
+  end
+
+  def update
+    message = Message.find(params[:id])
+    if message.update(edit_message_params)
+      flash[:notice] = "メッセージ編集に成功しました"
+      redirect_to "/users/#{message.recipient_id}"
+    else
+      flash[:error] = message.errors.full_messages
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def edit_message_params
+    params.require(:message).permit(:message)
+  end
+
+  def correct_user
+    msg = Message.find(params[:id])
+    if user_signed_in? && msg.sender_id == current_user.id
+    else 
+      flash[:notice] = "無効な操作です。"
+      redirect_to root_path
+    end
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
+  
   def index
     @users = User.all
   end

--- a/app/views/messages/edit.html.erb
+++ b/app/views/messages/edit.html.erb
@@ -1,0 +1,10 @@
+<h2>メッセージ編集</h2>
+
+<%= form_with(model: @message, url: message_path(@message), method: :patch) do |f| %>
+  <p>メッセージ</p>
+  <div>
+    <%= f.text_area :message, value: @message.message, size: "50x10" %>
+  </div>
+  <br>
+  <%= f.submit '更新' %>
+<% end %>

--- a/app/views/messages/index.html.erb
+++ b/app/views/messages/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Sent Messages</h1>
-

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,7 +9,6 @@
   <% end %>
 
   <main class="show-main">
-    <p>Users#show</p>
       <%= @user.name %>
       <% @messages.each do |msg| %>
         <% if msg.sender_id == current_user.id %>
@@ -21,6 +20,7 @@
             <br>
             <%= msg.created_at%>
             <br>
+            <%= link_to "編集", edit_message_path(msg.id), class: "btn btn-primary" %>
           </div>
         <% elsif msg.sender_id == @user.id %>
           <div style="text-align: left;">


### PR DESCRIPTION
## 変更の概要
* メッセージ編集機能のアクセス制限追加。

## なぜこの変更をするのか
* 自分のメッセージのみ編集できるようにするため。
 
## やったこと
* [x] やったこと：自分のメッセージのみ編集ボタンがある。URL直打ちで他のユーザーのメッセージ編集不可。
* [ ] やっていないこと：cssは触っていません。

## 変更内容
【自分のメッセージのみ編集ボタン表示】

<img width="922" alt="image" src="https://github.com/gaburieru123/message_app2/assets/69755688/12f097e8-f978-4f2f-b806-d14c6b14a382">

【他のユーザーのメッセージ編集画面をURL直打ちした後の画面】
<img width="940" alt="image" src="https://github.com/gaburieru123/message_app2/assets/69755688/c9e2c993-8228-4e7f-8679-386b4685af2b">

## 影響範囲
* ユーザーに影響すること：自分のメッセージのみ編集可能
* メンバーに影響すること：特になし
* システムに影響すること：特になし

## どうやるのか
* 使い方：編集画面に行って自分のメッセージのみ編集出来ることを確認する。

## 課題
* 悩んでいること：特になし
* とくにレビューしてほしいところ：特になし

## 備考
* その他に伝えたいこと：特になし