### PR TITLE
論理削除途中コミット

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,4 @@ group :test do
 end
 
 gem 'devise'
+gem 'discard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    discard (1.3.0)
+      activerecord (>= 4.2, < 8)
     erubi (1.12.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -231,6 +233,7 @@ DEPENDENCIES
   capybara
   debug
   devise
+  discard
   importmap-rails
   jbuilder
   puma (~> 5.0)

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -59,3 +59,12 @@ body{
 .header_user_name{
   background-color: gray;
 }
+.user{
+  margin: 10px;
+}
+.name{
+  margin: 0;
+}
+
+
+

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
-
+ # binding.b
   before_action :configure_permitted_parameters, if: :devise_controller?
-  before_action :current_user
 
   protected
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,10 @@
+class Users::RegistrationsController < ApplicationController
+  def destroy
+    resource.soft_delete
+    Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    set_flash_message :notice, :destroyed
+    yield resource if block_given?
+    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+  end
+  
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,105 @@
+# # frozen_string_literal: true
+
+# class Users::SessionsController < Devise::SessionsController 
+#  # < DeviseController
+#  prepend_before_action :require_no_authentication, only: [:new, :create]
+#  prepend_before_action :allow_params_authentication!, only: :create
+#  prepend_before_action :verify_signed_out_user, only: :destroy
+#  prepend_before_action(only: [:create, :destroy]) { request.env["devise.skip_timeout"] = true }
+
+#  # GET /resource/sign_in
+#  def new
+#   binding.b
+#    self.resource = resource_class.new(sign_in_params)
+#    clean_up_passwords(resource)
+#    yield resource if block_given?
+#    respond_with(resource, serialize_options(resource))
+#  end
+
+#  # POST /resource/sign_in
+#  def create
+#    self.resource = warden.authenticate!(auth_options)
+#    set_flash_message!(:notice, :signed_in)
+#    sign_in(resource_name, resource)
+#    yield resource if block_given?
+#    respond_with resource, location: after_sign_in_path_for(resource)
+#  end
+
+class Users::SessionsController < Devise::SessionsController
+ # POST /resource/sign_in
+ def create
+  binding.b
+   self.resource = warden.authenticate!(auth_options)
+   if resource.deleted_at.nil?
+    flash[:notice] = 'アカウント有効ですよー。'
+     set_flash_message!(:notice, :signed_in)
+     sign_in(resource_name, resource)
+     yield resource if block_given?
+     respond_with resource, location: after_sign_in_path_for(resource)
+   else
+    puts "テストデバッグ"
+     flash[:alert] = "アカウントは無効ですよー。"
+     redirect_to new_user_session_path
+   end
+ end
+end
+
+
+#  # DELETE /resource/sign_out
+#  def destroy
+#    signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+#    set_flash_message! :notice, :signed_out if signed_out
+#    yield if block_given?
+#    respond_to_on_destroy
+#  end
+
+#  protected
+
+#  def sign_in_params
+#    devise_parameter_sanitizer.sanitize(:sign_in)
+#  end
+
+#  def serialize_options(resource)
+#    methods = resource_class.authentication_keys.dup
+#    methods = methods.keys if methods.is_a?(Hash)
+#    methods << :password if resource.respond_to?(:password)
+#    { methods: methods, only: [:password] }
+#  end
+
+#  def auth_options
+#    { scope: resource_name, recall: "#{controller_path}#new", locale: I18n.locale }
+#  end
+
+#  def translation_scope
+#    'devise.sessions'
+#  end
+
+#  private
+
+#  # Check if there is no signed in user before doing the sign out.
+#  #
+#  # If there is no signed in user, it will set the flash message and redirect
+#  # to the after_sign_out path.
+#  def verify_signed_out_user
+#    if all_signed_out?
+#      set_flash_message! :notice, :already_signed_out
+
+#      respond_to_on_destroy
+#    end
+#  end
+
+#  def all_signed_out?
+#    users = Devise.mappings.keys.map { |s| warden.user(scope: s, run_callbacks: false) }
+
+#    users.all?(&:blank?)
+#  end
+
+#  def respond_to_on_destroy
+#    # We actually need to hardcode this as Rails default responder doesn't
+#    # support returning empty response on GET request
+#    respond_to do |format|
+#      format.all { head :no_content }
+#      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name), status: Devise.responder.redirect_status }
+#    end
+#  end
+# end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,23 +4,70 @@ class UsersController < ApplicationController
   def index
     @users = User.all
   end
+
+#   def index
+#    @users = User.where(deleted_at: nil)
+# end
   
+
+def create
+ binding.b
+  self.resource = warden.authenticate!(auth_options)
+  if resource.deleted_at.nil?
+    set_flash_message!(:notice, :signed_in)
+    sign_in(resource_name, resource)
+    yield resource if block_given?
+    respond_with resource, location: after_sign_in_path_for(resource)
+  else
+    flash.now[:alert] = "アカウントは無効ですよー。"
+    redirect_to new_user_session_path
+  end
+end
+
+
   def show
     @user = User.find(params[:id])
-    @sent_messages = current_user.sent_messages.where(recipient_id: params[:id])
-    @received_messages = @user.sent_messages.where(recipient_id: current_user.id)
+    sent_messages = current_user.sent_messages.where(recipient_id: params[:id])
+    received_messages = @user.sent_messages.where(recipient_id: current_user.id)
     if current_user.id == @user.id
-      @messages = @sent_messages
+      @messages = sent_messages
     elsif
-      @messages = (@sent_messages + @received_messages).sort_by(&:created_at)
+      @messages = (sent_messages + received_messages).sort_by(&:created_at)
     end
   end
 
-  def destroy
-    user = User.find(params[:id])
-    if user.id == current_user.id && user.destroy
+  # def destroy
+  #   user = User.find(params[:id])
+  #   if user.id == current_user.id && user.destroy
+  #     flash[:notice] = "アカウント削除に成功しました"
+  #     redirect_to new_user_registration_path
+  #   else
+  #     flash[:notice] = "無効な操作です。アカウント削除はできません。"
+  #     redirect_to user_path
+  #   end
+  # end
+
+  # def destroy
+  #  user = User.find(params[:id])
+  #   if user.id == current_user.id && user.update(deleted_at: Time.now)
+  #     flash[:notice] = "アカウント削除に成功しました"
+  #     redirect_to root_path
+  #   else
+  #     flash[:notice] = "無効な操作です。アカウント削除はできません。"
+  #     redirect_to user_path
+  #   end
+  # end
+
+  def update
+   user = User.find(params[:id])
+   # user = User.where.not(deleted_at: nil).where(id: params[:id]).first
+   # or
+   # binding.b
+   # user = User.where.not(deleted_at: nil).find_by(id: params[:id])
+    if user.id == current_user.id && user.update(deleted_at: Time.now)
+      sign_out(:user)
       flash[:notice] = "アカウント削除に成功しました"
-      redirect_to new_user_registration_path
+      redirect_to root_path
     else
       flash[:notice] = "無効な操作です。アカウント削除はできません。"
       redirect_to user_path

--- a/app/helpers/users/registrations_helper.rb
+++ b/app/helpers/users/registrations_helper.rb
@@ -1,0 +1,2 @@
+module Users::RegistrationsHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,22 @@ class User < ApplicationRecord
 
   has_many :sent_messages, class_name: 'Message', foreign_key: 'sender_id'
   has_many :received_messages, class_name: 'Message', foreign_key: 'recipient_id'
+
+    # # 物理削除の代わりにユーザーの`deleted_at`をタイムスタンプで更新
+    # def soft_delete  
+    #   update_attribute(:deleted_at, Time.current)  
+    # end
+  
+    # ユーザーのアカウントが有効であることを確認 
+    def active_for_authentication?
+     super && deleted_at.nil?
+    end
+  
+    # # 削除したユーザーにカスタムメッセージを追加します  
+    # def inactive_message   
+    #   !deleted_at ? super : :deleted_account  
+    # end 
       
+
+    
 end

--- a/app/views/layouts/_show_header.html.erb
+++ b/app/views/layouts/_show_header.html.erb
@@ -7,7 +7,7 @@
             <div><%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: "text-white" %></div>
             <% if @user.id == current_user.id %>
               <p class="d-flex justify-content-end">
-                <div><%= button_to "アカウント削除", user_path(current_user.id), method: :delete, data: { turbo_confirm: "本当に削除しますか?" }, class: "text-white" %></div>
+                <div><%= button_to "アカウント削除", user_path(current_user.id), method: :patch, data: { turbo_confirm: "本当に削除しますか?" }, class: "text-white" %></div>
               </p>
             <% end %>
         <% else %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,13 +1,17 @@
-
-  <% @users.each do |user| %>
-    <div class="one-post card w-100">
-      <%= link_to user_path(user) do %>
-        <p class="caption h4"><%= user.name %></p>
-        <% if user.id != current_user.id%>  
-          <%= link_to "ユーザーへメッセージ", user_path(user), class: "text-white" %>
-        <% elsif user.id == current_user.id %>
-          <%= link_to "メモ", user_path(user), class: "text-white" %>
+<div class="container">
+  <div class="element">
+    <% @users.each do |user| %>
+      <div class="user">
+        <%= link_to user_path(user) do %>
+          <div class="name"><%= user.name %>
+          <% if user.id != current_user.id%>  
+            <%= link_to "ユーザーへメッセージ", user_path(user), class: "text-white" %>
+          <% elsif user.id == current_user.id %>
+            <%= link_to "メモ", user_path(user), class: "text-white" %>
+          <% end %>
+        </div>
         <% end %>
-      <% end %>
-    </div>
-  <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
 
   root to: "homes#index"
 
-  devise_for :users
+  devise_for :users,controllers: { sessions: 'users/sessions' }
+
   resources :users
 
   resources :messages

--- a/db/migrate/20240417130405_add_deleted_at_to_users.rb
+++ b/db/migrate/20240417130405_add_deleted_at_to_users.rb
@@ -1,0 +1,12 @@
+class AddDeletedAtToUsers < ActiveRecord::Migration[7.0]
+  def up
+    add_column :users, :deleted_at, :datetime, null: true
+  end
+
+  def down
+   remove_column :users, :deleted_at
+  end
+
+end
+
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_02_062205) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_17_130405) do
   create_table "messages", force: :cascade do |t|
     t.string "message"
     t.datetime "created_at", null: false
@@ -28,6 +28,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_02_062205) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/users/registrations_controller_test.rb
+++ b/test/controllers/users/registrations_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Users::RegistrationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要
*論理削除実装途中

## なぜこの変更をするのか
* 変更をする理由；ユーザーを削除してもメッセージを残すため

## やったこと
* [x] やったこと；削除フラグ（deleted_atカラムに日付入れる）つけて値入っていたら削除対象。
* [ ] やっていないこと；
　削除された対象がログインできていないときに、フラッシュメッセージを表示する。
　削除されたユーザーの名前を消す

## 変更内容
* UIの変更ならスクリーンショット
<img width="1439" alt="image" src="https://github.com/gaburieru123/message_app2/assets/69755688/4d3fc2e6-849b-4aa5-9f82-334c12dda634">


## 影響範囲
* ユーザーに影響すること；削除したらログインできない。相手へのメッセージは相手からは閲覧可能。
* メンバーに影響すること；特になし
* システムに影響すること；特になし

## どうやるのか
* 使い方：アカウント削除ボタンをクリックする

## 課題
* 悩んでいること；論理削除したユーザー・論理削除していないユーザー共に、flaashメッセージの表示ができない。
* とくにレビューしてほしいところ；悩んでいることの解決ヒント教えて欲しい。

## 備考
* その他に伝えたいこと；特になし